### PR TITLE
🔍 Search 기능 구현 및 테스트 완료

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,7 @@ class User(Base):
     comments = relationship("Comment", back_populates='user')
     likes = relationship('Like', back_populates='user')
 
+
 class Post(Base):
     __tablename__ = "posts"
     id = Column(Integer, primary_key=True)
@@ -33,7 +34,6 @@ class Post(Base):
     tags = relationship('Tag',secondary='posttags', viewonly=True)
     book = relationship("Book", back_populates='posts')
     likes = relationship('Like', back_populates='post')
-    
 
 
 class Tag(Base):
@@ -53,7 +53,6 @@ class PostTag(Base):
     posts = relationship('Post', back_populates='posttags')
     
     
-
 class Comment(Base):
     __tablename__ = "comments"
     id = Column(Integer, primary_key=True)
@@ -85,6 +84,7 @@ class Follow(Base):
     following_id = Column(Integer, ForeignKey("users.id"), primary_key=True)  # 팔로우 당하는 사람
     created_at = Column(DateTime, default=datetime.now)
     
+
 class Book(Base):
     __tablename__ = 'books'
     id = Column(Integer, primary_key=True)

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from app.database import get_db
 from app.models import User as UserModel
-from app.schemas import UserCreate, UserResponse, LoginRequest
+from app.schemas import UserCreate, UserResponse, Login as LoginRequest
 from app.security import PasswordHasher, create_access_token, get_current_user
 
 router = APIRouter(prefix="/auth", tags=["Auth"])  # 인증 엔드포인트

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import or_
+from app.database import get_db
+from app.models import Post, Book, Tag
+from app.schemas import SearchResult
+
+
+router = APIRouter(prefix="/search", tags=["Search"])
+
+@router.get("/", response_model=list[SearchResult])
+def search(
+    q: str = "",
+    tags: list[str] = Query(default=[]), # 최대 3개 선택
+    page: int = 1,
+    db: Session = Depends(get_db)
+):
+    query = db.query(Post).join(Book).outerjoin(Post.tags)
+
+    # 포스트 제목 또는 책 제목 like 검색
+    if q:
+        query = query.filter(
+            or_(
+                Post.title.ilike(f"%{q}%"),
+                Book.title.ilike(f"%{q}%")
+            )
+        )
+
+    # 태그 검색(최대 3개)
+    if tags:
+        query = query.filter(Tag.name.in_(tags))
+
+    # ISBN 정확히 일치
+    if q.isdigit() and len(q) in [10, 13]:
+        query = query.filter(Book.isbn == q)
+
+    # 페이지네이션
+    page_size = 10
+    results = query.offset(
+        (page - 1) * page_size).limit(page_size).all()
+    
+    return [
+        SearchResult(
+            post_id=post.id,
+            title=post.title,
+            book_title=post.book.title,
+            tags=[tag.name for tag in post.tags],
+            isbn=post.book.isbn,
+            created_at=post.created_at
+        )
+        for post in results
+    ]

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -178,3 +178,14 @@ class Post(BaseModel):
     tags : List[TagResponse]
     
     model_config = ConfigDict(from_attributes=True)
+
+
+class SearchResult(BaseModel):
+    post_id: int
+    title: str
+    book_title: str
+    isbn: str
+    tags: List[str]
+    created_at: datetime.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 from app.database import create_table
 from app.routers.auth import router as auth_router # auth.py의 라우터 연결
 from app.routers.follows import router as follow_router
+from app.routers.search import router as search_router
 
 app= FastAPI()
 
@@ -21,6 +22,8 @@ def validation_handler(request, exc):
 # 라우터 연결
 app.include_router(auth_router)
 app.include_router(follow_router)
+app.include_router(search_router)
+
 
 @app.get('/healthy')
 def health_check():


### PR DESCRIPTION
### 📁 작업 파일
- app/routers/search.py
- app/schemas.py
- main.py

### 🛠️ 주요 구현 내용
#### 1. /search API 구현
- FastAPI APIRouter로 /search GET 엔드포인트 생성

- 검색 조건:
q: 게시글 제목 또는 책 제목 부분 일치 검색 (ILIKE)
tags: 최대 3개의 태그 필터링 (Tag.name.in_)
q가 ISBN 형식일 경우 정확히 일치하는 책 검색
페이지네이션 적용 (page 파라미터, 10개씩 분할)

- SQLAlchemy 조인:
Post ↔ Book (inner join)
Post ↔ Tag (outer join)

#### 2. SearchResult 응답 모델 정의
- schemas.py에 SearchResult Pydantic 모델 추가

```python
class SearchResult(BaseModel):
    post_id: int
    title: str
    book_title: str
    isbn: str
    tags: List[str]
    created_at: datetime.datetime
    model_config = ConfigDict(from_attributes=True)
```
> FastAPI에서 response_model=list[SearchResult]로 사용

#### 3. 라우터 등록
- main.py에 search_router 등록

```python
from app.routers.search import router as search_router
app.include_router(search_router)
```
### ✅ 테스트 내역
#### Postman 테스트
GET /search
- 정상적으로 빈 리스트 반환 (게시글 없음 상태)
- 로그인 후 토큰 발급 → Authorization: Bearer <token> 헤더에 포함

#### 🔐 로그인 요청 방식 변경
기존: Form 방식으로 로그인 요청 처리 (Form(...))
변경: Pydantic 모델 기반으로 JSON 요청 처리

- schemas.py에 Login 모델 정의
- auth.py에서 Login 모델을 LoginRequest로 import하여 사용
- 요청 형식 변경에 따라 Swagger 문서 및 Postman 테스트 방식도 JSON 기반으로 수정됨

### 관련 이슈
- Closes #36
