### PR TITLE
✅ 회원 탈퇴 시 비밀번호 검증 추가

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -84,6 +84,10 @@ class UserResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class WithdrawRequest(BaseModel):
+    password: str
+
+
 class Comment(BaseModel):
     content: TrimmedStr = Field(max_length=1000)
     


### PR DESCRIPTION
- 회원 탈퇴 시 사용자의 현재 비밀번호를 입력받아 검증하도록 변경(schemas.py에 요청 schema 추가)
- 테스트 완료(비밀번호가 맞지 않을 시 401 Unauthorized 에러)

#### 관련 이슈
Closes #67 